### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PyGDX is a Python package for accessing data stored in *GAMS Data eXchange* (GDX
 
 Originally inspired by the similar package, also named [py-gdx, by Geoff Leyland](https://github.com/geoffleyland/py-gdx), this version makes use of [xarray](http://xarray.pydata.org) to provide labelled data structures which can be easily manipulated with [NumPy](http://www.numpy.org) for calculations and plotting.
 
-**Documentation** is available at http://pygdx.readthedocs.org, built automatically from the contents of the Github repository.
+**Documentation** is available at https://pygdx.readthedocs.io, built automatically from the contents of the Github repository.
 
 PyGDX is provided under the **MIT License** (see `LICENSE`).
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,7 @@ import sys, os
 
 
 class Mock(object):
-    """Per http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-
+    """Per https://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-
     import-errors-on-libraries-that-depend-on-c-modules"""
     __all__ = []
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
