### PR TITLE
gams_dir can be explicitly defined

### DIFF
--- a/gdx/__init__.py
+++ b/gdx/__init__.py
@@ -19,7 +19,7 @@ debug = logger.debug
 info = logger.info
 
 
-__version__ = '2'
+__version__ = '3'
 
 
 __all__ = [
@@ -63,7 +63,7 @@ class File(xr.Dataset):
         super(File, self).__init__()  # Invoke Dataset constructor
 
         # load the GDX API
-        self._api = GDX(gams_dir)
+        self._api = GDX(gams_dir=gams_dir)
         self._api.open_read(str(filename))
 
         # Basic information about the GDX file

--- a/gdx/__init__.py
+++ b/gdx/__init__.py
@@ -40,6 +40,8 @@ class File(xr.Dataset):
     constructed, containing only the labels appearing in the respective
     dimension of that parameter.
 
+    gams_dir can be explicitly defined in case gams does not exist in PATH.
+
     .. note::
 
        For instance, the GAMS Parameter ``foo(*,*,*)`` is loaded as
@@ -56,12 +58,12 @@ class File(xr.Dataset):
     _alias = {}
     _implicit = False
 
-    def __init__(self, filename='', lazy=True, implicit=True, skip=set()):
+    def __init__(self, filename='', lazy=True, implicit=True, gams_dir=None, skip=set()):
         """Constructor."""
         super(File, self).__init__()  # Invoke Dataset constructor
 
         # load the GDX API
-        self._api = GDX()
+        self._api = GDX(gams_dir)
         self._api.open_read(str(filename))
 
         # Basic information about the GDX file

--- a/gdx/api.py
+++ b/gdx/api.py
@@ -73,11 +73,13 @@ class GDX(object):
         'SystemInfo',
         ]
 
-    def __init__(self):
+    def __init__(self, gams_dir=None):
         """Constructor."""
         self._handle = gdxcc.new_gdxHandle_tp()
         self.error_count = 0
-        self.call('CreateD', str(_gams_dir()), gdxcc.GMS_SSSIZE)
+        if gams_dir is None:
+            gams_dir = str(_gams_dir())
+        self.call('CreateD', gams_dir, gdxcc.GMS_SSSIZE)
 
     def call(self, method, *args):
         """Invoke the GDX API method named gdx\ *Method*.

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name='gdx',
         'backports.shutil_which',
         'future',
         'xarray',
+        'gdxcc'
         ],
       tests_require=['pytest'],
       url='https://github.com/khaeru/py-gdx',


### PR DESCRIPTION
I had trouble running the library without defining explicitly the gams directory as my GAMS installaiton couldn't be located by 'which'.

Moreover I added gdxcc as a requirement in setup.py so that it can be automatically installed by pypi (maintained by me [here](https://github.com/kavvkon/gams-api) )